### PR TITLE
Fixes / improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,20 +2,21 @@
 # Makefile for lsignal
 #
 
-CXX=g++
-CXXFLAGS=-std=c++11 -c -O3 -Wall
-LDFLAGS=
+CXX?=g++
+CXXFLAGS?=-std=c++11 -O3 -Wall
+LDFLAGS?=
 EXECUTABLE=lsignal
 SOURCES=main.cpp
 OBJECTS=$(SOURCES:.cpp=.o)
 
+.PHONY: all
 all: $(SOURCES) $(EXECUTABLE)
 
 $(EXECUTABLE): $(OBJECTS)
 	$(CXX) $(LDFLAGS) $(OBJECTS) -o $@
 
-.cpp.o:
-	$(CXX) $(CXXFLAGS) $< -o $@
+%.o : %.cpp lsignal.h
+	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 clean:
 	rm -f *.o $(EXECUTABLE)

--- a/lsignal.h
+++ b/lsignal.h
@@ -371,16 +371,23 @@ namespace lsignal
 	{
 		std::lock_guard<std::mutex> locker(_mutex);
 
-		for (auto iter = _callbacks.begin(); iter != _callbacks.end(); ++iter)
+		for (const auto& jnt : _callbacks)
 		{
-			const joint& jnt = *iter;
-
 			if (jnt.owner != nullptr)
 			{
 				jnt.owner->_data = nullptr;
-				jnt.owner->_deleter = std::move(std::function<void(std::shared_ptr<connection_data>)>());
+				jnt.owner->_cleaners.clear();
 			}
 		}
+		_callbacks.clear();
+		for (auto sig : _children)
+		{
+			if (sig->_parent == this) // should be an assert
+			{
+				sig->_parent = nullptr;
+			}
+		}
+		_children.clear();
 	}
 
 	template<typename R, typename... Args>

--- a/main.cpp
+++ b/main.cpp
@@ -190,6 +190,16 @@ int main(int argc, char *argv[])
 	}
 	sig7();
 
+        // example 8
+	std::cout << "\nexample #8: disconnect_all\n";
+
+	signal<void()> sig8;
+	sig8.connect(bar);
+	sig8.connect(bar);
+	sig8.connect(bar);
+	sig8.disconnect_all();
+	sig8();
+
 
 	// check performance
 	lsignal::signal<void()> ls;

--- a/main.cpp
+++ b/main.cpp
@@ -177,6 +177,20 @@ int main(int argc, char *argv[])
 
 	first(10);
 
+        // example 7
+	std::cout << "\nexample #7: slot\n";
+
+	signal<void()> sig7;
+	{
+		slot s;
+
+		// sig7.connect(bar, &s); // compile error
+		sig7.connect([](){ std::cout << "sig7\n"; }, &s);
+		sig7();
+	}
+	sig7();
+
+
 	// check performance
 	lsignal::signal<void()> ls;
 	boost::signals2::signal_type<void(), boost::signals2::keywords::mutex_type<boost::signals2::dummy_mutex>>::type bs;


### PR DESCRIPTION
Hello Ievgen Polyvanyi,

searching a simple signal library I found lsignal and it looks promising. Here are some fixes / improvements for it (see commit message). 

Addinional notes:
* When I try to compile tests.cpp (with g++ 4.9 or clang++ 3.5) I get a compile error:
tests.cpp: In static member function ‘static void AssertHelper::VerifyValue(int, int, const char*)’:
tests.cpp:52:118: error: no matching function for call to ‘std::exception::exception(const char*)’
    throw std::exception(MakeString("\n\n  %s\n\n    Excepted: %d\n    Actual: %d", message, expected, actual).c_str());

* In QT the slot is the function, that is connected to the signal, so the signal calls the slot. In your library I understand that a slot is something like an automatic disconnector. I suggest to change the name of the class slot to something like shared_connection. 

Greetings
Diether Knof